### PR TITLE
Add NavigationBar/Rail examples with modular views

### DIFF
--- a/NavRailAndNavBarExample.py
+++ b/NavRailAndNavBarExample.py
@@ -1,24 +1,34 @@
 import flet as ft
 
+from views.home_view import HomeView
+from views.cart_view import CartView
+from views.profile_view import ProfileView
+
+
 def main(page: ft.Page):
+    """Example using NavigationRail and NavigationBar."""
     page.title = "Mini Amazon - Navegación"
     page.theme_mode = ft.ThemeMode.LIGHT
 
-    label = ft.Text("¡Bienvenido a Mini Amazon!")
+    # Container to show the current view
+    current_view = ft.Container(expand=True)
 
-    def on_navigation_change(e):
-        opciones = ["Home", "Cart", "Profile"]
-        seleccion = opciones[e.control.selected_index]
-        label.value = f"Ahora estás en: {seleccion}"
+    # Instantiate views created in separate modules
+    views = [HomeView(), CartView(), ProfileView()]
+    current_view.content = views[0]  # start on Home
+
+    def on_navigation_change(e: ft.ControlEvent):
+        """Callback to switch visible view."""
+        current_view.content = views[e.control.selected_index]
         page.update()
 
     nav = ft.NavigationBar(
         destinations=[
             ft.NavigationBarDestination(icon=ft.Icons.HOME, label="Home"),
             ft.NavigationBarDestination(icon=ft.Icons.SHOPPING_CART, label="Cart"),
-            ft.NavigationBarDestination(icon=ft.Icons.PERSON, label="Profile")
+            ft.NavigationBarDestination(icon=ft.Icons.PERSON, label="Profile"),
         ],
-        on_change=on_navigation_change
+        on_change=on_navigation_change,
     )
 
     rail = ft.NavigationRail(
@@ -26,19 +36,28 @@ def main(page: ft.Page):
         destinations=[
             ft.NavigationRailDestination(icon=ft.Icons.HOME, label="Home"),
             ft.NavigationRailDestination(icon=ft.Icons.SHOPPING_CART, label="Cart"),
-            ft.NavigationRailDestination(icon=ft.Icons.PERSON, label="Profile")
+            ft.NavigationRailDestination(icon=ft.Icons.PERSON, label="Profile"),
         ],
-        on_change=on_navigation_change
+        on_change=on_navigation_change,
     )
 
+    # Layout with NavigationRail on the left and NavigationBar on top
     page.add(
-        ft.Row([
-            rail,
-            ft.Column([
-                nav,
-                label
-            ])
-        ])
+        ft.Row(
+            [
+                rail,
+                ft.Column(
+                    [
+                        nav,
+                        current_view,
+                    ],
+                    expand=True,
+                ),
+            ],
+            expand=True,
+        )
     )
 
-ft.app(target=main)
+
+if __name__ == "__main__":
+    ft.app(target=main)

--- a/OnlyNavBarExample.py
+++ b/OnlyNavBarExample.py
@@ -1,0 +1,34 @@
+import flet as ft
+
+from views.home_view import HomeView
+from views.cart_view import CartView
+from views.profile_view import ProfileView
+
+
+def main(page: ft.Page):
+    """Example using only NavigationBar."""
+    page.title = "Ejemplo NavigationBar"
+    page.theme_mode = ft.ThemeMode.LIGHT
+
+    current_view = ft.Container(expand=True)
+    views = [HomeView(), CartView(), ProfileView()]
+    current_view.content = views[0]
+
+    def on_change(e: ft.ControlEvent):
+        current_view.content = views[e.control.selected_index]
+        page.update()
+
+    nav = ft.NavigationBar(
+        destinations=[
+            ft.NavigationBarDestination(icon=ft.Icons.HOME, label="Home"),
+            ft.NavigationBarDestination(icon=ft.Icons.SHOPPING_CART, label="Cart"),
+            ft.NavigationBarDestination(icon=ft.Icons.PERSON, label="Profile"),
+        ],
+        on_change=on_change,
+    )
+
+    page.add(ft.Column([nav, current_view], expand=True))
+
+
+if __name__ == "__main__":
+    ft.app(target=main)

--- a/OnlyNavRailExample.py
+++ b/OnlyNavRailExample.py
@@ -1,0 +1,35 @@
+import flet as ft
+
+from views.home_view import HomeView
+from views.cart_view import CartView
+from views.profile_view import ProfileView
+
+
+def main(page: ft.Page):
+    """Example using only NavigationRail."""
+    page.title = "Ejemplo NavigationRail"
+    page.theme_mode = ft.ThemeMode.LIGHT
+
+    current_view = ft.Container(expand=True)
+    views = [HomeView(), CartView(), ProfileView()]
+    current_view.content = views[0]
+
+    def on_change(e: ft.ControlEvent):
+        current_view.content = views[e.control.selected_index]
+        page.update()
+
+    rail = ft.NavigationRail(
+        selected_index=0,
+        destinations=[
+            ft.NavigationRailDestination(icon=ft.Icons.HOME, label="Home"),
+            ft.NavigationRailDestination(icon=ft.Icons.SHOPPING_CART, label="Cart"),
+            ft.NavigationRailDestination(icon=ft.Icons.PERSON, label="Profile"),
+        ],
+        on_change=on_change,
+    )
+
+    page.add(ft.Row([rail, current_view], expand=True))
+
+
+if __name__ == "__main__":
+    ft.app(target=main)

--- a/views/cart_view.py
+++ b/views/cart_view.py
@@ -1,0 +1,12 @@
+import flet as ft
+
+class CartView(ft.UserControl):
+    """Shopping cart screen."""
+
+    def build(self) -> ft.Control:
+        return ft.Column(
+            [
+                ft.Text("Carrito", size=24, weight=ft.FontWeight.BOLD),
+                ft.Text("Aquí van los productos agregados"),
+            ]
+        )

--- a/views/home_view.py
+++ b/views/home_view.py
@@ -1,0 +1,12 @@
+import flet as ft
+
+class HomeView(ft.UserControl):
+    """Simple home screen."""
+
+    def build(self) -> ft.Control:
+        return ft.Column(
+            [
+                ft.Text("Home", size=24, weight=ft.FontWeight.BOLD),
+                ft.Text("Bienvenido a la tienda de ejemplo"),
+            ]
+        )

--- a/views/profile_view.py
+++ b/views/profile_view.py
@@ -1,0 +1,12 @@
+import flet as ft
+
+class ProfileView(ft.UserControl):
+    """User profile screen."""
+
+    def build(self) -> ft.Control:
+        return ft.Column(
+            [
+                ft.Text("Perfil", size=24, weight=ft.FontWeight.BOLD),
+                ft.Text("Información del usuario"),
+            ]
+        )


### PR DESCRIPTION
## Summary
- add simple view classes under `views/`
- demonstrate NavigationRail and NavigationBar in `NavRailAndNavBarExample.py`
- create stand‑alone NavigationBar and NavigationRail examples

## Testing
- `python -m py_compile NavRailAndNavBarExample.py OnlyNavBarExample.py OnlyNavRailExample.py views/*.py`

------
https://chatgpt.com/codex/tasks/task_e_6841b6b15fa4832fb6ade6c69a890eaa